### PR TITLE
search using optional query param

### DIFF
--- a/db/simDB.js
+++ b/db/simDB.js
@@ -32,7 +32,12 @@ const simDB = {
     setTimeout(() => {
       try {
         // let list = term ? this.data.filter(item => item.name.includes(term)) : this.data;
-        let list = this.data.filter(item => Object.keys(query).every(key => item[key] === query[key]));
+        const queryKeys = Object.keys(query);
+        let list = this.data;
+        if (queryKeys.length > 0) {
+          list = this.data.filter(item => Object.keys(query).every(key => item[key].includes(query[key])));
+        }
+        
         callback(null, list);
       } catch (err) {
         callback(err);

--- a/db/simDB.js
+++ b/db/simDB.js
@@ -35,9 +35,9 @@ const simDB = {
         const queryKeys = Object.keys(query);
         let list = this.data;
         if (queryKeys.length > 0) {
-          list = this.data.filter(item => Object.keys(query).every(key => item[key].includes(query[key])));
+          list = this.data.filter(item => queryKeys.every(key => item[key].includes(query[key])));
         }
-        
+
         callback(null, list);
       } catch (err) {
         callback(err);

--- a/server.js
+++ b/server.js
@@ -25,8 +25,10 @@ app.use(express.json());
 // Get All (and search by query)
 app.get('/api/notes', (req, res, next) => {
   const { searchTerm } = req.query;
+  let query;
+  if (searchTerm) query = { title: searchTerm };
 
-  notes.filter(searchTerm, (err, list) => {
+  notes.filter(query, (err, list) => {
     if (err) {
       return next(err);
     }


### PR DESCRIPTION
If keeping the optional `query` param API for the `filter` method, this is a proposed solution. I'm not sure this was original intention? The incoming `?searchTerm` param is still expecting to only search on `title` and not `content`, so the route has to do the work of converting the string into a query object. This feels a little convoluted for students to create at this point in course?